### PR TITLE
AwaitDatastoreChanges NullReferenceException fix

### DIFF
--- a/BobbyTables/DatastoreManager.cs
+++ b/BobbyTables/DatastoreManager.cs
@@ -443,11 +443,14 @@ namespace BobbyTables
 				foreach (var store in datastores)
 				{
 					var delta = allDeltas[store.Handle];
-					if (delta["notfoundresult"] == null)
-					{
-						store.ApplyChanges(delta);
-						changed.Add(store);
-					}
+                    if (delta != null)
+                    {
+                        if (delta["notfoundresult"] == null)
+                        {
+                            store.ApplyChanges(delta);
+                            changed.Add(store);
+                        }
+                    }
 				}
 			}
 			return changed.Count > 0;


### PR DESCRIPTION
When AwaitDatastoreChanges is called and a local datastore does not have
get_deltas, a NullReferenceException is thrown.
