### PR TITLE
If remote row does not have Id property, rowid isn't used to populate local Id property

### DIFF
--- a/BobbyTables.Tests/DatastoreTests.cs
+++ b/BobbyTables.Tests/DatastoreTests.cs
@@ -551,6 +551,35 @@ namespace BobbyTables.Tests
 ]".Replace(" ", string.Empty).Replace("\t", string.Empty).Replace("\r\n", string.Empty)), Times.Exactly(1));
 		}
 
+        [Test]
+        public void Pull_WhenRemoteDoesNotHaveIdColumn_MapRowIdToId()
+        {
+            var mockGetRequest = new Mock<IApiRequest>();
+            mockGetRequest.Setup(req => req.GetResponse()).Returns(new ApiResponse(200, @"{""handle"": ""yyyy"", ""rev"": 28, ""created"": false}"));
+            mockGetRequest.Setup(req => req.AddParam(It.IsAny<string>(), It.IsAny<string>()));
+
+            var mockSnapshotRequest = new Mock<IApiRequest>();
+            mockSnapshotRequest.Setup(req => req.GetResponse()).Returns(new ApiResponse(200, @"{""rows"": [{""tid"": ""test_objects"", ""data"": {""ByteArray"": {""B"": ""_wEA""},""EnumValue"": {""I"":""1""},""UInt32Value"": {""I"": ""6""}, ""FloatValue"": 3.0, ""ByteList"": {""B"": ""AAH_""}, ""TimeValue"": {""T"": ""486086400000""}, ""LongValue"": {""I"": ""9""}, ""Int32Value"": {""I"": ""3""}, ""DoubleValue"": 1.0, ""IntList"": [{""I"": ""1""}, {""I"": ""2""}, {""I"": ""3""}], ""IntValue"": {""I"": ""1""}, ""Int16Value"": {""I"": ""2""}, ""UIntValue"": {""I"": ""4""}, ""UInt16Value"": {""I"": ""5""}, ""ULongValue"": {""I"": ""10""}, ""StringValue"": ""hello"", ""Int64Value"": {""I"": ""7""}, ""SingleValue"": 2.0, ""StringList"": [""hello"", ""world""], ""UInt64Value"": {""I"": ""8""}}, ""rowid"": ""1""}], ""rev"": 28}"));
+            mockSnapshotRequest.Setup(req => req.AddParam(It.IsAny<string>(), It.IsAny<string>()));
+
+            RequestFactory
+                .Setup(api => api.CreateRequest("POST", "get_or_create_datastore", Manager.ApiToken))
+                .Returns(mockGetRequest.Object);
+
+            RequestFactory
+                .Setup(api => api.CreateRequest("POST", "get_snapshot", Manager.ApiToken))
+                .Returns(mockSnapshotRequest.Object);
+
+            var db = Manager.GetOrCreate("default");
+            db.Pull();
+
+            var table = db.GetTable<TestObject>("test_objects");
+            var item = table.Get("1");
+
+            Assert.IsNotNull(item);
+            Assert.AreEqual(item.Id, "1");
+        }
+
 		[Test]
 		public void AwaitPull()
 		{


### PR DESCRIPTION
When reading data created by a client which does not use de Id property to store rowid, the Id property of the object returned by Get<T>() isn't populated.
This prevents the data from being saved back to the datastore.

I don't know if the way I implemented it captures the intended use of the library, but the bottom line is that this issue prevents BobbyTables from working with data generated by clients that do not adhere to its convention.
